### PR TITLE
Fix refresh inner

### DIFF
--- a/Sources/VisibilityTrackableCollectionView/Inner/InnerCellViewModelList.swift
+++ b/Sources/VisibilityTrackableCollectionView/Inner/InnerCellViewModelList.swift
@@ -26,23 +26,59 @@ extension VisibilityTrackableCollectionView {
             guard indexPaths.isNotEmpty else { return }
             
             indexPaths.forEach { indexPath in
+                guard
+                    let (innerTracker, inner) = findInnerVisibilityTracker(parent: parent, key: indexPath)
+                else {
+                    addInnerItemIfNotContains(indexPath)
+                    return
+                }
+                refreshIfNeeded(inner: inner, innerTracker: innerTracker)
                 addInnerItemIfNotContains(indexPath)
-                reload(using: parent, at: indexPath)
+                reload(inner: inner, innerTracker: innerTracker)
             }
+        }
+
+        func findInnerVisibilityTracker(
+            parent: VisibilityTrackableCollectionViewInterface?
+            , key: IndexPath
+        ) -> (InnerVisibilityTrackerInterface, InnerViewModel)? {
+            guard
+                let inner = inners.first(where: { $0.key == key }),
+                let innerCell = parent?.cellForItem(at: inner.key) as? InnerVisibilityTrackerInterface
+            else {
+                return nil
+            }
+
+            return (innerCell, inner)
         }
         
         func notiRefreshToInner(using parent: VisibilityTrackableCollectionViewInterface?) {
+            var removeItems: [InnerViewModel] = []
             inners.forEach {
-                guard let cell = parent?.cellForItem(at: $0.key) as? InnerVisibilityTrackerInterface else { return }
+                guard
+                    let cell = parent?.cellForItem(at: $0.key) as? InnerVisibilityTrackerInterface
+                else {
+                    $0.isNeedRefresh = true
+                    return
+                }
+                
                 cell.refreshSeenDataToInnerCollectionView()
+                $0.data.refreshSeenData()
+                removeItems.append($0)
             }
+            
+            removeItems.forEach { removeInner(inner: $0) }
+        }
+        
+        private func removeInner(inner: InnerViewModel) {
+            inners = inners.filter { $0.key != inner.key }
         }
         
         func reload(using parent: VisibilityTrackableCollectionViewInterface?, at key: IndexPath) {
             guard let inner = inners.first(where: { $0.key == key }),
                   let innerCell = parent?.cellForItem(at: inner.key) as? InnerVisibilityTrackerInterface
             else { return }
-                
+            
             innerCell.configureInnerCollectionView(inner.data)
         }
         

--- a/Sources/VisibilityTrackableCollectionView/Inner/InnerFooterViewModelList.swift
+++ b/Sources/VisibilityTrackableCollectionView/Inner/InnerFooterViewModelList.swift
@@ -28,23 +28,63 @@ extension VisibilityTrackableCollectionView {
             guard indexPaths.isNotEmpty else { return }
             
             indexPaths.forEach { indexPath in
+                guard
+                    let (innerTracker, inner) = findInnerVisibilityTracker(parent: parent, key: indexPath)
+                else {
+                    addInnerItemIfNotContains(indexPath)
+                    return
+                }
+                refreshIfNeeded(inner: inner, innerTracker: innerTracker)
                 addInnerItemIfNotContains(indexPath)
-                reload(using: parent, at: indexPath)
+                reload(inner: inner, innerTracker: innerTracker)
             }                        
         }
         
-        func notiRefreshToInner(using parent: VisibilityTrackableCollectionViewInterface?) {
-            inners.forEach {
-                guard let view = parent?.supplementaryView(forElementKind: kind, at: $0.key) as? InnerVisibilityTrackerInterface else { return }
-                view.refreshSeenDataToInnerCollectionView()
+        func findInnerVisibilityTracker(
+            parent: VisibilityTrackableCollectionViewInterface?
+            , key: IndexPath
+        ) -> (InnerVisibilityTrackerInterface, InnerViewModel)? {
+            guard
+                let inner = inners.first(where: { $0.key == key })
+                , let view = parent?.supplementaryView(forElementKind: kind, at: inner.key) as? InnerVisibilityTrackerInterface
+            else {
+                return nil
             }
+            
+            return (view, inner)
+        }
+        
+        func notiRefreshToInner(using parent: VisibilityTrackableCollectionViewInterface?) {
+            var removeItems: [InnerViewModel] = []
+            inners.forEach {
+                guard
+                    let view = parent?.supplementaryView(
+                        forElementKind: kind,
+                        at: $0.key
+                    ) as? InnerVisibilityTrackerInterface
+                else {
+                    $0.isNeedRefresh = true
+                    return
+                }
+                view.refreshSeenDataToInnerCollectionView()
+                $0.data.refreshSeenData()
+                removeItems.append($0)
+            }
+            
+            removeItems.forEach { removeInner(inner: $0) }
         }
         
         func reload(using parent: VisibilityTrackableCollectionViewInterface?, at key: IndexPath) {
-            guard let inner = inners.first(where: { $0.key == key }),
-                  let view = parent?.supplementaryView(forElementKind: kind, at: inner.key) as? InnerVisibilityTrackerInterface
-            else { return }
-                
+            guard
+                let inner = inners.first(where: { $0.key == key }),
+                let view = parent?.supplementaryView(
+                    forElementKind: kind,
+                    at: inner.key
+                ) as? InnerVisibilityTrackerInterface
+            else {
+                return
+            }
+            
             view.configureInnerCollectionView(inner.data)
         }
         

--- a/Sources/VisibilityTrackableCollectionView/Inner/InnerHeaderViewModelList.swift
+++ b/Sources/VisibilityTrackableCollectionView/Inner/InnerHeaderViewModelList.swift
@@ -27,23 +27,66 @@ extension VisibilityTrackableCollectionView {
             guard indexPaths.isNotEmpty else { return }
             
             indexPaths.forEach { indexPath in
+                guard
+                    let (innerTracker, inner) = findInnerVisibilityTracker(parent: parent, key: indexPath)
+                else {
+                    addInnerItemIfNotContains(indexPath)
+                    return
+                }
+                refreshIfNeeded(inner: inner, innerTracker: innerTracker)
                 addInnerItemIfNotContains(indexPath)
-                reload(using: parent, at: indexPath)
+                reload(inner: inner, innerTracker: innerTracker)
             }                        
         }
         
-        func notiRefreshToInner(using parent: VisibilityTrackableCollectionViewInterface?) {
-            inners.forEach {
-                guard let view = parent?.supplementaryView(forElementKind: kind, at: $0.key) as? InnerVisibilityTrackerInterface else { return }
-                view.refreshSeenDataToInnerCollectionView()
+        func findInnerVisibilityTracker(
+            parent: VisibilityTrackableCollectionViewInterface?,
+            key: IndexPath
+        ) -> (InnerVisibilityTrackerInterface, InnerViewModel)? {
+            guard
+                let inner = inners.first(where: { $0.key == key }),
+                let view = parent?.supplementaryView(
+                    forElementKind: kind,
+                    at: inner.key
+                ) as? InnerVisibilityTrackerInterface
+            else {
+                return nil
             }
+            
+            return (view, inner)
+        }
+
+        func notiRefreshToInner(using parent: VisibilityTrackableCollectionViewInterface?) {
+            var removeItems: [InnerViewModel] = []
+            inners.forEach {
+                guard
+                    let view = parent?.supplementaryView(
+                        forElementKind: kind,
+                        at: $0.key
+                    ) as? InnerVisibilityTrackerInterface
+                else {
+                    $0.isNeedRefresh = true
+                    return
+                }
+                view.refreshSeenDataToInnerCollectionView()
+                $0.data.refreshSeenData()
+                removeItems.append($0)
+            }
+            
+            removeItems.forEach { removeInner(inner: $0) }
         }
         
         func reload(using parent: VisibilityTrackableCollectionViewInterface?, at key: IndexPath) {
-            guard let inner = inners.first(where: { $0.key == key }),
-                  let view = parent?.supplementaryView(forElementKind: kind, at: inner.key) as? InnerVisibilityTrackerInterface
-            else { return }
-                
+            guard
+                let inner = inners.first(where: { $0.key == key }),
+                let view = parent?.supplementaryView(
+                    forElementKind: kind,
+                    at: inner.key
+                ) as? InnerVisibilityTrackerInterface
+            else {
+                return
+            }
+            
             view.configureInnerCollectionView(inner.data)
         }
         

--- a/Sources/VisibilityTrackableCollectionView/Inner/InnerViewModelListInterface.swift
+++ b/Sources/VisibilityTrackableCollectionView/Inner/InnerViewModelListInterface.swift
@@ -10,6 +10,8 @@
 import Foundation
 
 protocol InnerViewModelListInterface: AnyObject {
+    typealias InnerViewModel = VisibilityTrackableCollectionView.InnerViewModel
+    
     var type: VisibilityTrackableViewType { get }
     var inners: [VisibilityTrackableCollectionView.InnerViewModel] { get set }
     
@@ -19,11 +21,15 @@ protocol InnerViewModelListInterface: AnyObject {
     func reload(using parent: VisibilityTrackableCollectionViewInterface?, at key: IndexPath)
     func refresh()
     func addInnerItemIfNotContains(_ key: IndexPath)
+    func findInnerVisibilityTracker(
+        parent: VisibilityTrackableCollectionViewInterface?,
+        key: IndexPath
+     ) -> (InnerVisibilityTrackerInterface, InnerViewModel)?
 }
 
 extension InnerViewModelListInterface {
     
-    func findInnerItem(using key: IndexPath) -> VisibilityTrackableCollectionView.InnerViewModel? {
+    func findInnerItem(using key: IndexPath) -> InnerViewModel? {
         inners.first(where: { $0.key == key })
     }
     
@@ -39,6 +45,27 @@ extension InnerViewModelListInterface {
     func refresh() {
         inners.forEach { $0.data.refreshSeenData() }
         inners = []
+    }
+    
+    func refreshIfNeeded(
+        inner: InnerViewModel,
+        innerTracker: InnerVisibilityTrackerInterface
+    ) {
+        guard inner.isNeedRefresh else { return }
+        innerTracker.refreshSeenDataToInnerCollectionView()
+        inner.data.refreshSeenData()
+        removeInner(inner: inner)
+    }
+
+    func removeInner(inner: InnerViewModel) {
+        inners = inners.filter { $0.key != inner.key }
+    }
+
+    func reload(
+        inner: InnerViewModel,
+        innerTracker: InnerVisibilityTrackerInterface
+    ) {
+        innerTracker.configureInnerCollectionView(inner.data)
     }
     
 }

--- a/Sources/VisibilityTrackableCollectionView/Inner/InnerVisibilityTrackableCollectionViewModel.swift
+++ b/Sources/VisibilityTrackableCollectionView/Inner/InnerVisibilityTrackableCollectionViewModel.swift
@@ -14,6 +14,7 @@ extension VisibilityTrackableCollectionView {
     final class InnerViewModel {
         let key: IndexPath
         var data = ViewModel()
+        var isNeedRefresh: Bool = false
         
         init(key: IndexPath) {
             self.key = key

--- a/Sources/VisibilityTrackableCollectionView/VisibilityTrackableCollectionViewModel.swift
+++ b/Sources/VisibilityTrackableCollectionView/VisibilityTrackableCollectionViewModel.swift
@@ -44,7 +44,6 @@ extension VisibilityTrackableCollectionView {
         func refreshSeenData() {
             visibleItemManagers.forEach { $0.refreshSeenData() }
             infiniteVisibleItemManagers.forEach { $0.refreshSeenData() }
-            innerViewModelLists.forEach { $0.refresh() }
         }
         
         func refreshInfiniteItems(type: VisibilityTrackableViewType) {


### PR DESCRIPTION
When cell and reusable view are nil, the flag is saved and used when retrieving it later.